### PR TITLE
Add Google Public DNS resolvers behind the VPC resolver

### DIFF
--- a/config/consul.json
+++ b/config/consul.json
@@ -1,6 +1,8 @@
 {
   "recursors": [
-    "169.254.169.253"
+    "169.254.169.253",
+    "8.8.8.8",
+    "8.8.4.4"
   ],
   "disable_update_check": true,
   "raft_protocol": 3


### PR DESCRIPTION
Related to bfb76698bdb5b117dd374280953e860925a6e3a8

It looks more like occasional lookup failures have to do with network hiccups as opposed to a failure of remote resolver. Giving Consul more than one resolver to try should reduce the likelihood of ultimately returning a failure to the client.